### PR TITLE
Add appendix on the use with RFC 9031

### DIFF
--- a/draft-selander-ace-ake-authz.md
+++ b/draft-selander-ace-ake-authz.md
@@ -62,7 +62,7 @@ informative:
   I-D.irtf-cfrg-hpke:
   I-D.selander-ace-coap-est-oscore:
   I-D.ietf-lake-edhoc:
-  I-D.palombini-core-oscore-edhoc:
+  I-D.ietf-core-oscore-edhoc:
 
 --- abstract
 
@@ -393,7 +393,7 @@ The Sig_or_MAC_3 field calculated using the private key corresponding to PK_U is
 
 EAD_3 MAY contain an enrolment request, see e.g. CSR specified in {{I-D.mattsson-cose-cbor-cert-compress}}, or other request which the device is now authorized to make.
 
-EDHOC message_3 may be combined with an OSCORE request, see {{I-D.palombini-core-oscore-edhoc}}.
+EDHOC message_3 may be combined with an OSCORE request, see {{I-D.ietf-core-oscore-edhoc}}.
 
 #### Authenticator processing
 
@@ -644,9 +644,46 @@ IANA has registered the following entry in the "EDHOC External Authorization Dat
 
 # Use with Constrained Join Protocol (CoJP)
 
-## TODO:
+## TODO
 
-* Draw a figure with CoJP exchange following authz flow
+~~~~~~~~~~~
+U                                    V                              W
+|                                    |                              |
+|                                    |                              |
++- - - - - - - - - - - - - - - - - ->|                              |
+|    Optional network solicitation   |                              |
+|<-----------------------------------+                              |
+|          Network discovery         |                              |
+|                                    |                              |
++----------------------------------->|                              |
+|          EDHOC message_1           |                              |
+|                                    +----------------------------->|
+|                                    |    Voucher Request (VREQ)    |
+|                                    |<-----------------------------+
+|                                    |    Voucher Response (VRES)   |
+|<-----------------------------------+                              |
+|          EDHOC message_2           |                              |
+|                                    |                              |
+|                                    |                              |
++----------------------------------->|                              |
+|   EDHOC message_3 + CoJP request   |                              |
+|                                    |                              |
++<-----------------------------------|                              |
+|            CoJP response           |                              |
+|
+~~~~~~~~~~~
+{: #fig-cojp title="Use of draft-selander-ace-ake-authz with CoJP." artwork-align="center"}
+
+
+* TODO1: Discuss network discovery in:
+
+1. 802.15.4 TSCH
+1. 802.15.4 non-TSCH
+
+* TODO2: Processing of EDHOC messages follows Section {{U-V}}
+* TODO3: CoJP is piggybacked on EDHOC message 3
+    * reference {{I-D.ietf-core-oscore-edhoc}}
+
 * Map U and V to the pledge and JRC
 * Map ID_U to pledge identifier
 * Map EDHOC PRK_out to PSK in RFC 9031

--- a/draft-selander-ace-ake-authz.md
+++ b/draft-selander-ace-ake-authz.md
@@ -729,7 +729,6 @@ OSCORE-protected payload is the CoJP Join Request object specified in Section 8.
 OSCORE protection leverages the OSCORE Security Context derived from the EDHOC exchange, as specified in Appendix A of {{I-D.ietf-lake-edhoc}}.
 To that end, {{I-D.ietf-core-oscore-edhoc}} specifies that the Sender ID of the client (device) must be set to the connection identifier selected by the domain authenticator, C_R.
 OSCORE includes the Sender ID as the kid in the OSCORE option.
-In addition, following {{RFC9031}} the ID Context MUST be set to the pledge identifier, ID_U.
 The network identifier in the CoJP Join Request object is set to the network identifier obtained from the network discovery phase.
 In case of IEEE 802.15.4 networks, this is the PAN ID.
 
@@ -743,20 +742,14 @@ The device SHALL map the message to a CoAP request:
 * The EDHOC option {{I-D.ietf-core-oscore-edhoc}} is set and is empty.
 * The payload is prepared as described in Section 3.2. of {{I-D.ietf-core-oscore-edhoc}}, with EDHOC message_3 and the CoJP Join Request object as the OSCORE-protected payload.
 
+Note that the OSCORE Sender IDs are derived from the connection identifiers of the EDHOC exchange.
+This is in contrast with {{RFC9031}} where ID Context of the OSCORE Security Context is set to the device identifier (pledge identifier).
+Since the device identity is exchanged during the EDHOC handshake, and the certificate of the device is communicated to the authenticator as part of the Voucher Response message, there is no need to transport the device identity in OSCORE messages.
+The authenticator playing the role of the {{RFC9031}} JRC obtains the device identity from the execution of the authorization protocol.
+
 ### Message 4
 
-The authenticator processes message 3 as per Section 3.3. of {{I-D.ietf-core-oscore-edhoc}}.
-
-
-
-## CoJP exchange
-
-* TODO3: CoJP is piggybacked on EDHOC message 3
-    * reference {{I-D.ietf-core-oscore-edhoc}}
-
-* Map U and V to the pledge and JRC
-* Map ID_U to pledge identifier
-* Map EDHOC PRK_out to PSK in RFC 9031
-* discuss how the network identifier is obtained
+Message 4 is the OSCORE response carrying CoJP response message.
+The message is processed as specified in Section 8.4.2. of {{RFC9031}}.
 
 --- fluff

--- a/draft-selander-ace-ake-authz.md
+++ b/draft-selander-ace-ake-authz.md
@@ -648,8 +648,8 @@ IANA has registered the following entry in the "EDHOC External Authorization Dat
 
 # Use with Constrained Join Protocol (CoJP)
 
-We outline how the protocol is used for network enrollment and parameter provisioning.
-We use IEEE 802.15.4 network as an example of how a new device (U) is enrolled into the domain managed by the domain authenticator (V).
+This section outlines how the protocol is used for network enrollment and parameter provisioning.
+An IEEE 802.15.4 network is used as an example of how a new device (U) can be enrolled into the domain managed by the domain authenticator (V).
 
 ~~~~~~~~~~~
 U                                    V                              W

--- a/draft-selander-ace-ake-authz.md
+++ b/draft-selander-ace-ake-authz.md
@@ -696,7 +696,7 @@ For simplicity, {{fig-cojp}} illustrates the case when the device and the domain
 
 ## The enrollment protocol with parameter provisioning
 
-### Message 1
+### Flight 1
 
 Once the device has discovered the network it wants to join, it constructs the EDHOC message_1, as described in {{U-V}}.
 The device SHALL map the message to a CoAP request:
@@ -709,9 +709,9 @@ The device SHALL map the message to a CoAP request:
 * The Content-Format option is set to "application/cid-edhoc+cbor-seq"
 * The payload is the (true, EDHOC message_1) CBOR sequence, where EDHOC message_1 is constructed as defined in {{U-V}}.
 
-### Message 2
+### Flight 2
 
-The domain authenticator receives the message 1 and processes it as described in {{U-V}}.
+The domain authenticator receives message_1 and processes it as described in {{U-V}}.
 The message triggers the exchange with the authorization server, as described in {{V-W}}.
 If the exchange between V and W completes successfully, the domain authenticator prepares EDHOC message_2, as described in {{U-V}}.
 The authenticator SHALL map the message to a CoAP response:
@@ -720,12 +720,12 @@ The authenticator SHALL map the message to a CoAP response:
 * The Content-Format option is set to "application/edhoc+cbor-seq"
 * The payload is the EDHOC message_2, as defined in {{U-V}}.
 
-### Message 3
+### Flight 3
 
-The device receives the message 2 and processes it as described in {{U-V}}}.
-Upon successful processing of message 2, the device prepares message 3, which is a combination of EDHOC message_3 and OSCORE-protected CoJP request.
+The device receives EDHOC message_2 and processes it as described in {{U-V}}}.
+Upon successful processing of message_2, the device prepares flight 3, which is an OSCORE-protected CoJP request containing an EDHOC message_3, as described in {{I-D.ietf-core-oscore-edhoc}}.
 EDHOC message_3 is prepared as described in {{U-V}}.
-OSCORE-protected payload is the CoJP Join Request object specified in Section 8.4.1. of {{RFC9031}}.
+The OSCORE-protected payload is the CoJP Join Request object specified in Section 8.4.1. of {{RFC9031}}.
 OSCORE protection leverages the OSCORE Security Context derived from the EDHOC exchange, as specified in Appendix A of {{I-D.ietf-lake-edhoc}}.
 To that end, {{I-D.ietf-core-oscore-edhoc}} specifies that the Sender ID of the client (device) must be set to the connection identifier selected by the domain authenticator, C_R.
 OSCORE includes the Sender ID as the kid in the OSCORE option.
@@ -747,9 +747,9 @@ This is in contrast with {{RFC9031}} where ID Context of the OSCORE Security Con
 Since the device identity is exchanged during the EDHOC handshake, and the certificate of the device is communicated to the authenticator as part of the Voucher Response message, there is no need to transport the device identity in OSCORE messages.
 The authenticator playing the role of the {{RFC9031}} JRC obtains the device identity from the execution of the authorization protocol.
 
-### Message 4
+### Flight 4
 
-Message 4 is the OSCORE response carrying CoJP response message.
+Flight 4 is the OSCORE response carrying CoJP response message.
 The message is processed as specified in Section 8.4.2. of {{RFC9031}}.
 
 --- fluff

--- a/draft-selander-ace-ake-authz.md
+++ b/draft-selander-ace-ake-authz.md
@@ -143,7 +143,7 @@ The domain authenticator has a private key and a corresponding public key PK_V u
 The domain authenticator needs to be able to locate the authorization server of the device for which LOC_W is expected to be sufficient.
 The communication between domain authenticator and authorization server is assumed to be mutually authenticated and protected; authentication credentials and communication security is out of scope, except for as specified below in this section.
 
-The domain authenticator may in principle use differents credentials for authenticating to the authorization server and to the device, for which PK_V is used.
+The domain authenticator may in principle use different credentials for authenticating to the authorization server and to the device, for which PK_V is used.
 However, the domain authenticator MUST prove possession of private key of PK_V to the authorization server since the authorization server is asserting (by means of the voucher to the device) that this credential belongs to the domain authenticator.
 
 In this version of the draft it is assumed that the domain authenticator authenticates to the authorization server with PK_V using some authentication protocol providing proof of possession of the private key, for example TLS 1.3 {{RFC8446}}.
@@ -640,7 +640,16 @@ IANA has registered the following entry in the "EDHOC External Authorization Dat
 +-------+------------+-----------------+
 ~~~~~~~~~~~
 
-
-
-
 --- back
+
+# Use with Constrained Join Protocol (CoJP)
+
+## TODO:
+
+* Draw a figure with CoJP exchange following authz flow
+* Map U and V to the pledge and JRC
+* Map ID_U to pledge identifier
+* Map EDHOC PRK_out to PSK in RFC 9031
+* discuss how the network identifier is obtained
+
+--- fluff


### PR DESCRIPTION
The PR adds an appendix that describes the use of draft-selander-ace-authz with the Constrained Join Protocol (CoJP), specified in RFC 9031. The PR also adds some details about network discovery where the text is applicable to IEEE 802.15.4 networks.